### PR TITLE
Moving to buster for `GLIBC_2.28' dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/replicatedhq/kots-lint
 RUN make build
 
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 RUN apt-get update -y && \
     apt-get install -y ca-certificates && \

--- a/Dockerfile.skaffold
+++ b/Dockerfile.skaffold
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/replicatedhq/kots-lint
 RUN make build
 
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 ENV DEBUG_MODE on
 


### PR DESCRIPTION
Upgrading deps to meet KOTS 1.56.0 requires a new version of glibc-2.28.  KOTS uses the debian:buster-slim image, using the same image here.