### PR TITLE
optimize rendering the manifests - creating a template builder is costly

### DIFF
--- a/pkg/kots/enterprise_lint.go
+++ b/pkg/kots/enterprise_lint.go
@@ -34,10 +34,15 @@ func EnterpriseLintSpecFiles(specFiles SpecFiles, policies []EnterprisePolicy) (
 		return nil, errors.Wrap(err, "failed to find config")
 	}
 
+	builder, err := getTemplateBuilder(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get template builder")
+	}
+
 	// get the rendered version of the spec files before linting
 	renderedFiles := SpecFiles{}
 	for _, file := range separatedSpecFiles {
-		renderedContent, err := file.renderContent(config)
+		renderedContent, err := file.renderContent(builder)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render spec file content")
 		}

--- a/pkg/kots/lint.go
+++ b/pkg/kots/lint.go
@@ -364,12 +364,17 @@ func lintRenderContent(specFiles SpecFiles) ([]LintExpression, SpecFiles, error)
 		lintExpressions = append(lintExpressions, lintExpression)
 	}
 
+	builder, err := getTemplateBuilder(config)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get  builder")
+	}
+
 	// rendering files is an expensive process, store and return the rendered files
 	// from this function so that they can be used later instead of rendering again on the fly
 	renderedFiles := SpecFiles{}
 
 	for _, file := range separatedSpecFiles {
-		renderedContent, err := file.renderContent(config)
+		renderedContent, err := file.renderContent(builder)
 		if err == nil {
 			file.Content = string(renderedContent)
 			renderedFiles = append(renderedFiles, file)

--- a/pkg/kots/lint.go
+++ b/pkg/kots/lint.go
@@ -366,7 +366,7 @@ func lintRenderContent(specFiles SpecFiles) ([]LintExpression, SpecFiles, error)
 
 	builder, err := getTemplateBuilder(config)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to get  builder")
+		return nil, nil, errors.Wrap(err, "failed to get template builder")
 	}
 
 	// rendering files is an expensive process, store and return the rendered files

--- a/pkg/kots/render.go
+++ b/pkg/kots/render.go
@@ -156,9 +156,10 @@ func getTemplateBuilder(config *kotsv1beta1.Config) (*template.Builder, error) {
 	}
 
 	opts := template.BuilderOptions{
-		ConfigGroups:   configGroups,
-		ExistingValues: templateContextValues,
-		LocalRegistry:  localRegistry,
+		ConfigGroups:    configGroups,
+		ExistingValues:  templateContextValues,
+		LocalRegistry:   localRegistry,
+		ApplicationInfo: &template.ApplicationInfo{}, // Kots 1.56.0 calls ApplicationInfo.Slug, this is required
 	}
 	builder, _, err := template.NewBuilder(opts)
 	if err != nil {

--- a/pkg/kots/render.go
+++ b/pkg/kots/render.go
@@ -33,9 +33,14 @@ func (files SpecFiles) render() (SpecFiles, error) {
 		return nil, errors.Wrap(err, "failed to find and validate config")
 	}
 
+	builder, err := getTemplateBuilder(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get template builder")
+	}
+
 	renderedFiles := SpecFiles{}
 	for _, file := range files {
-		renderedContent, err := file.renderContent(config)
+		renderedContent, err := file.renderContent(builder)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to render spec file %s", file.Path)
 		}
@@ -46,7 +51,7 @@ func (files SpecFiles) render() (SpecFiles, error) {
 	return renderedFiles, nil
 }
 
-func (f SpecFile) renderContent(config *kotsv1beta1.Config) ([]byte, error) {
+func (f SpecFile) renderContent(builder *template.Builder) ([]byte, error) {
 	if !f.isYAML() {
 		return nil, errors.New("not a yaml file")
 	}
@@ -57,25 +62,6 @@ func (f SpecFile) renderContent(config *kotsv1beta1.Config) ([]byte, error) {
 	}
 	if !s {
 		return []byte(f.Content), nil
-	}
-
-	localRegistry := template.LocalRegistry{}
-	templateContextValues := make(map[string]template.ItemValue)
-
-	configGroups := []kotsv1beta1.ConfigGroup{}
-	if config != nil && config.Spec.Groups != nil {
-		configGroups = config.Spec.Groups
-	}
-
-	opts := template.BuilderOptions{
-		ConfigGroups:    configGroups,
-		ExistingValues:  templateContextValues,
-		LocalRegistry:   localRegistry,
-		ApplicationInfo: &template.ApplicationInfo{}, // Kots 1.56.0 calls ApplicationInfo.Slug, this is required
-	}
-	builder, _, err := template.NewBuilder(opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create builder")
 	}
 
 	// add new line so that parsing the render template error is easier (possible)
@@ -158,6 +144,28 @@ func renderConfig(config *kotsv1beta1.Config) ([]byte, error) {
 	}
 
 	return b, nil
+}
+
+func getTemplateBuilder(config *kotsv1beta1.Config) (*template.Builder, error) {
+	localRegistry := template.LocalRegistry{}
+	templateContextValues := make(map[string]template.ItemValue)
+
+	configGroups := []kotsv1beta1.ConfigGroup{}
+	if config != nil && config.Spec.Groups != nil {
+		configGroups = config.Spec.Groups
+	}
+
+	opts := template.BuilderOptions{
+		ConfigGroups:   configGroups,
+		ExistingValues: templateContextValues,
+		LocalRegistry:  localRegistry,
+	}
+	builder, _, err := template.NewBuilder(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create builder")
+	}
+
+	return &builder, nil
 }
 
 func parseRenderTemplateError(file SpecFile, value string) RenderTemplateError {

--- a/pkg/kots/render_test.go
+++ b/pkg/kots/render_test.go
@@ -608,7 +608,10 @@ spec:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.file.renderContent(nil)
+			builder, err := getTemplateBuilder(nil)
+			require.NoError(t, err)
+
+			_, err = tt.file.renderContent(builder)
 
 			renderTemplateError, ok := errors.Cause(err).(RenderTemplateError)
 			assert.True(t, ok)

--- a/pkg/kots/render_test.go
+++ b/pkg/kots/render_test.go
@@ -467,9 +467,12 @@ spec:
 			require.NoError(t, err)
 			assert.Equal(t, path, tt.configPath)
 
+			builder, err := getTemplateBuilder(config)
+			require.NoError(t, err)
+
 			renderedFiles := SpecFiles{}
 			for _, file := range tt.files {
-				renderedContent, err := file.renderContent(config)
+				renderedContent, err := file.renderContent(builder)
 				require.NoError(t, err)
 				file.Content = string(renderedContent)
 				renderedFiles = append(renderedFiles, file)


### PR DESCRIPTION
### Before
times out after a minute

### After
```
real    0m4.692s
user    0m0.009s
sys     0m0.013s
```