### PR TITLE
tell users to ignore status informer warning for helm resources

### DIFF
--- a/pkg/kots/lint_test.go
+++ b/pkg/kots/lint_test.go
@@ -1515,7 +1515,7 @@ spec:
 					Rule:    "nonexistent-status-informer-object",
 					Type:    "warn",
 					Path:    "test.yaml",
-					Message: "Status informer points to a nonexistent kubernetes object",
+					Message: "Status informer points to a nonexistent kubernetes object. If this is a Helm resource, ignore the warning and proceed safely.",
 					Positions: []LintExpressionItemPosition{
 						{
 							Start: LintExpressionItemLinePosition{
@@ -1587,7 +1587,7 @@ spec:
 					Rule:    "nonexistent-status-informer-object",
 					Type:    "warn",
 					Path:    "test.yaml",
-					Message: "Status informer points to a nonexistent kubernetes object",
+					Message: "Status informer points to a nonexistent kubernetes object. If this is a Helm resource, ignore the warning and proceed safely.",
 					Positions: []LintExpressionItemPosition{
 						{
 							Start: LintExpressionItemLinePosition{
@@ -1703,7 +1703,7 @@ spec:
 					Rule:    "nonexistent-status-informer-object",
 					Type:    "warn",
 					Path:    "test.yaml",
-					Message: "Status informer points to a nonexistent kubernetes object",
+					Message: "Status informer points to a nonexistent kubernetes object. If this is a Helm resource, ignore the warning and proceed safely.",
 					Positions: []LintExpressionItemPosition{
 						{
 							Start: LintExpressionItemLinePosition{

--- a/pkg/kots/rego/kots-spec-opa-rendered.rego
+++ b/pkg/kots/rego/kots-spec-opa-rendered.rego
@@ -111,7 +111,7 @@ lint[output] {
   output := {
     "rule": "nonexistent-status-informer-object",
     "type": "warn",
-    "message": "Status informer points to a nonexistent kubernetes object",
+    "message": "Status informer points to a nonexistent kubernetes object. If this is a Helm resource, ignore the warning and proceed safely.",
     "path": file.path,
     "field": field,
     "docIndex": file.docIndex


### PR DESCRIPTION
Users can ignore the status informer warning for helm resources. This PR just adds that to the warning message.

[SH29009](https://app.shortcut.com/replicated/story/29009/kots-lint-warns-for-nonexistent-status-informer-object-defined-in-a-helm-chart)