### PR TITLE
check for ignored linting rule

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -1,4 +1,4 @@
-name: id
+name: kots-lint
 command: bash
 workdir: /go/src/github.com/replicatedhq/kots-lint
 sync:

--- a/pkg/kots/rego/kots-spec-opa-nonrendered.rego
+++ b/pkg/kots/rego/kots-spec-opa-nonrendered.rego
@@ -135,6 +135,9 @@ is_kots_kind(file) {
 } else {
   file.content.apiVersion == "app.k8s.io/v1beta1"
   file.content.kind == "Application"
+} else {
+  file.content.apiVersion == "app.k8s.io/v1beta1"
+  file.content.kind == "LintConfig"
 }
 kots_kinds[output] {
   file := files[_]
@@ -216,11 +219,14 @@ template_yamlPath_ends_with_array(template) {
 
 # Check if any files are missing "kind"
 lint[output] {
+  rule_name := "missing-kind-field"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   file := files[_]
   not file.content.kind
   output := {
-    "rule": "missing-kind-field",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing \"kind\" field",
     "path": file.path,
     "docIndex": file.docIndex
@@ -229,11 +235,14 @@ lint[output] {
 
 # Check if any files are missing "apiVersion"
 lint[output] {
+  rule_name := "missing-api-version-field"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   file := files[_]
   not file.content.apiVersion
   output := {
-    "rule": "missing-api-version-field",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing \"apiVersion\" field",
     "path": file.path,
     "docIndex": file.docIndex
@@ -252,11 +261,14 @@ v1beta2_preflight_spec_exists {
   file.content.apiVersion == "troubleshoot.sh/v1beta2"
 }
 lint[output] {
+  rule_name := "preflight-spec"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
   not v1beta1_preflight_spec_exists
   not v1beta2_preflight_spec_exists
   output := {
-    "rule": "preflight-spec",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing preflight spec"
   }
 }
@@ -268,10 +280,13 @@ config_spec_exists {
   file.content.apiVersion == "kots.io/v1beta1"
 }
 lint[output] {
+  rule_name := "config-spec"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
   not config_spec_exists
   output := {
-    "rule": "config-spec",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing config spec"
   }
 }
@@ -298,13 +313,16 @@ v1beta2_supportbundle_spec_exists {
   file.content.apiVersion == "troubleshoot.sh/v1beta2"
 }
 lint[output] {
+  rule_name := "troubleshoot-spec"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
   not v1beta1_troubleshoot_spec_exists
   not v1beta2_troubleshoot_spec_exists
   not v1beta1_supportbundle_spec_exists
   not v1beta2_supportbundle_spec_exists
   output := {
-    "rule": "troubleshoot-spec",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing troubleshoot spec"
   }
 }
@@ -316,23 +334,29 @@ application_spec_exists {
   file.content.apiVersion == "kots.io/v1beta1"
 }
 lint[output] {
+  rule_name := "application-spec"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
   not application_spec_exists
   output := {
-    "rule": "application-spec",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing application spec"
   }
 }
 
 # Check if Application icon exists
 lint[output] {
+  rule_name := "application-icon"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
   file := files[_]
   file.content.kind == "Application"
   file.content.apiVersion == "kots.io/v1beta1"
   not file.content.spec.icon
   output := {
-    "rule": "application-icon",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing application icon",
     "path": file.path,
     "field": "spec",
@@ -341,13 +365,16 @@ lint[output] {
 }
 
 lint[output] {
+  rule_name := "application-statusInformers"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
   file := files[_]
   file.content.kind == "Application"
   file.content.apiVersion == "kots.io/v1beta1"
   not file.content.spec.statusInformers
   output := {
-    "rule": "application-statusInformers",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing application statusInformers",
     "path": file.path,
     "field": "spec",
@@ -357,14 +384,17 @@ lint[output] {
 
 # Check if targetKotsVersion in the Application spec is a valid semver
 lint[output] {
+  rule_name := "invalid-target-kots-version"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   file := files[_]
   file.content.kind == "Application"
   file.content.apiVersion == "kots.io/v1beta1"
   file.content.spec.targetKotsVersion
   not semver.is_valid(trim_prefix(file.content.spec.targetKotsVersion, "v"))
   output := {
-    "rule": "invalid-target-kots-version",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Target KOTS version must be a valid semver",
     "path": file.path,
     "field": "spec.targetKotsVersion",
@@ -374,14 +404,17 @@ lint[output] {
 
 # Check if minKotsVersion in the Application spec is a valid semver
 lint[output] {
+  rule_name := "invalid-min-kots-version"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   file := files[_]
   file.content.kind == "Application"
   file.content.apiVersion == "kots.io/v1beta1"
   file.content.spec.minKotsVersion
   not semver.is_valid(trim_prefix(file.content.spec.minKotsVersion, "v"))
   output := {
-    "rule": "invalid-min-kots-version",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Minimum KOTS version must be a valid semver",
     "path": file.path,
     "field": "spec.minKotsVersion",
@@ -400,12 +433,15 @@ is_addon_version_invalid(version) {
   version == "latest"
 }
 lint[output] {
+  rule_name := "invalid-kubernetes-installer"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   file := files[_]
   is_kubernetes_installer(file)
   is_addon_version_invalid(file.content.spec[addon].version)
   output := {
-    "rule": "invalid-kubernetes-installer",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Add-ons included in the Kubernetes installer must pin specific versions rather than 'latest' or x-ranges (e.g., 1.2.x).",
     "path": file.path,
     "field": sprintf("spec.%s.version", [string(addon)]),
@@ -415,12 +451,15 @@ lint[output] {
 
 # Check if the kubernetes installer is using the old deprecated api version
 lint[output] {
+  rule_name := "deprecated-kubernetes-installer-version"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
   file := files[_]
   file.content.kind == "Installer"
   file.content.apiVersion == "kurl.sh/v1beta1"
   output := {
-    "rule": "deprecated-kubernetes-installer-version",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "API version 'kurl.sh/v1beta1' is deprecated. Use 'cluster.kurl.sh/v1beta1' instead.",
     "path": file.path,
     "field": "apiVersion",
@@ -442,13 +481,16 @@ is_same_kots_kind(k1, k2) {
   k1.kind == k2.kind
 }
 lint[output] {
+  rule_name := "duplicate-kots-kind"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   kki := kots_kinds[i]
   kkj := kots_kinds[j]
   i != j
   is_same_kots_kind(kki, kkj)
   output := {
-    "rule": "duplicate-kots-kind",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": sprintf("A release can only include one '%s' resource, but another '%s' resource was found in %s", [string(kki.kind), string(kki.kind), string(kkj.filePath)]),
     "path": kki.filePath,
     "field": "apiVersion",
@@ -475,11 +517,14 @@ is_valid_helm_release_name(name) {
   count(name) <= 53
 }
 lint[output] {
+  rule_name := "invalid-helm-release-name"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   rn := helm_release_names[_]
   not is_valid_helm_release_name(rn.releaseName)
   output := {
-    "rule": "invalid-helm-release-name",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Invalid Helm release name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 53",
     "path": rn.filePath,
     "field": "spec.chart.releaseName",
@@ -489,13 +534,16 @@ lint[output] {
 
 # Check if the releaseName field in HelmChart CRDs is unique across all charts
 lint[output] {
+  rule_name := "duplicate-helm-release-name"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   rni := helm_release_names[i]
   rnj := helm_release_names[j]
   i != j
   rni.releaseName == rnj.releaseName
   output := {
-    "rule": "duplicate-helm-release-name",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": sprintf("Release name is already used in %s", [string(rnj.filePath)]),
     "path": rni.filePath,
     "field": "spec.chart.releaseName",
@@ -505,12 +553,15 @@ lint[output] {
 
 # Check if any spec has "replicas" set to 1
 lint[output] {
+  rule_name := "replicas-1"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   spec.spec.replicas == 1
   field := concat(".", [spec.field, "replicas"])
   output := {
-    "rule": "replicas-1",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Found Replicas 1",
     "path": spec.path,
     "field": field,
@@ -520,12 +571,15 @@ lint[output] {
 
 # Check if any spec has "privileged" set to true
 lint[output] {
+  rule_name := "privileged"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   spec.spec.privileged == true
   field := concat(".", [spec.field, "privileged"])
   output := {
-    "rule": "privileged",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Found privileged spec",
     "path": spec.path,
     "field": field,
@@ -535,12 +589,15 @@ lint[output] {
 
 # Check if any spec has "allowPrivilegeEscalation" set to true
 lint[output] {
+  rule_name := "allow-privilege-escalation"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   spec.spec.allowPrivilegeEscalation == true
   field := concat(".", [spec.field, "allowPrivilegeEscalation"])
   output := {
-    "rule": "allow-privilege-escalation",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Allows privilege escalation",
     "path": spec.path,
     "field": field,
@@ -550,14 +607,17 @@ lint[output] {
 
 # Check if any "Container Image" contains the tag ":latest"
 lint[output] {
+  rule_name := "container-image-latest-tag"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   is_string(container.image)
   endswith(container.image, ":latest")
   field := concat(".", [spec.field, "containers", string(index), "image"])
   output := {
-    "rule": "container-image-latest-tag",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Container has image with tag 'latest'",
     "path": spec.path,
     "field": field,
@@ -567,14 +627,17 @@ lint[output] {
 
 # Check if any "Container Image" uses "LocalImageName"
 lint[output] {
+  rule_name := "container-image-local-image-name"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   is_string(container.image)
   re_match("^(repl{{|{{repl)\\s*LocalImageName", container.image)
   field := concat(".", [spec.field, "containers", string(index), "image"])
   output := {
-    "rule": "container-image-local-image-name",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Container image utilizes LocalImageName",
     "path": spec.path,
     "field": field,
@@ -584,13 +647,16 @@ lint[output] {
 
 # Check if any "Container" of a spec doesn’t have field "resources"
 lint[output] {
+  rule_name := "container-resources"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   not container.resources
   field := concat(".", [spec.field, "containers", string(index)])
   output := {
-    "rule": "container-resources",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing container resources",
     "path": spec.path,
     "field": field,
@@ -600,14 +666,17 @@ lint[output] {
 
 # Check if any "Resource" doesn’t have field "limits"
 lint[output] {
+  rule_name := "container-resource-limits"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   container.resources
   not container.resources.limits
   field := concat(".", [spec.field, "containers", string(index), "resources"])
   output := {
-    "rule": "container-resource-limits",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing resource limits",
     "path": spec.path,
     "field": field,
@@ -617,14 +686,17 @@ lint[output] {
 
 # Check if any "Resource" doesn’t have field "requests"
 lint[output] {
+  rule_name := "container-resource-requests"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   container.resources
   not container.resources.requests
   field := concat(".", [spec.field, "containers", string(index), "resources"])
   output := {
-    "rule": "container-resource-requests",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing resource requests",
     "path": spec.path,
     "field": field,
@@ -634,14 +706,17 @@ lint[output] {
 
 # Check if any "Resource Limits" doesn’t have field "cpu"
 lint[output] {
+  rule_name := "resource-limits-cpu"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   container.resources.limits
   not container.resources.limits.cpu
   field := concat(".", [spec.field, "containers", string(index), "resources", "limits"])
   output := {
-    "rule": "resource-limits-cpu",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing resource cpu limit",
     "path": spec.path,
     "field": field,
@@ -651,14 +726,17 @@ lint[output] {
 
 # Check if any "Resource Limits" doesn’t have field "memory"
 lint[output] {
+  rule_name := "resource-limits-memory"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   container.resources.limits
   not container.resources.limits.memory
   field := concat(".", [spec.field, "containers", string(index), "resources", "limits"])
   output := {
-    "rule": "resource-limits-memory",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing resource memory limit",
     "path": spec.path,
     "field": field,
@@ -668,14 +746,17 @@ lint[output] {
 
 # Check if any "Resource Requests" doesn’t have field "cpu"
 lint[output] {
+  rule_name := "resource-requests-cpu"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   container.resources.requests
   not container.resources.requests.cpu
   field := concat(".", [spec.field, "containers", string(index), "resources", "requests"])
   output := {
-    "rule": "resource-requests-cpu",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing requests cpu limit",
     "path": spec.path,
     "field": field,
@@ -685,14 +766,17 @@ lint[output] {
 
 # Check if any "Resource Requests" doesn’t have field "memory"
 lint[output] {
+  rule_name := "resource-requests-memory"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   container := spec.spec.containers[index]
   container.resources.requests
   not container.resources.requests.memory
   field := concat(".", [spec.field, "containers", string(index), "resources", "requests"])
   output := {
-    "rule": "resource-requests-memory",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Missing requests memory limit",
     "path": spec.path,
     "field": field,
@@ -702,13 +786,16 @@ lint[output] {
 
 # Check if any "Volume" of a spec has field "hostPath"
 lint[output] {
+  rule_name := "volumes-host-paths"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   volume := spec.spec.volumes[index]
   volume.hostPath
   field := concat(".", [spec.field, "volumes", string(index), "hostPath"])
   output := {
-    "rule": "volumes-host-paths",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Volume has hostpath",
     "path": spec.path,
     "field": field,
@@ -718,13 +805,16 @@ lint[output] {
 
 # Check if any "Volume" of a spec has field "hostPath" set to "docker.sock"
 lint[output] {
+  rule_name := "volume-docker-sock"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   spec := specs[_]
   volume := spec.spec.volumes[index]
   volume.hostPath.path == "/var/run/docker.sock"
   field := concat(".", [spec.field, "volumes", string(index), "hostPath", "path"])
   output := {
-    "rule": "volume-docker-sock",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Volume mounts docker.sock",
     "path": spec.path,
     "field": field,
@@ -734,13 +824,16 @@ lint[output] {
 
 # Check if any "namespace" is hardcoded
 lint[output] {
+  rule_name := "hardcoded-namespace"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   file := files[_]
   namespace := file.content.metadata.namespace
   is_string(namespace)
   not re_match("^(repl{{|{{repl)", namespace)
   output := {
-    "rule": "hardcoded-namespace",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Found a hardcoded namespace",
     "path": file.path,
     "field": "metadata.namespace",
@@ -750,6 +843,9 @@ lint[output] {
 
 # Check if any file may contain secrets
 lint[output] {
+  rule_name := "may-contain-secrets"
+  rule_config := lint_rule_config(rule_name, "info")
+  not rule_config.off
   file := input[_] # using "input" instead if "files" because "file.content" is string in "input"
   expression := secrets_regular_expressions[_]
   expression_matches := regex.find_n(expression, file.content, -1)
@@ -757,8 +853,8 @@ lint[output] {
   match := expression_matches[_]
   not re_match("repl{{|{{repl", match) # exclude if template function
   output := {
-    "rule": "may-contain-secrets",
-    "type": "info",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "It looks like there might be secrets in this file",
     "path": file.path,
     "docIndex": object.get(file, "docIndex", 0),
@@ -768,6 +864,9 @@ lint[output] {
 
 # Check if ConfigOption has a valid type
 lint[output] {
+  rule_name := "config-option-invalid-type"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   config_option := config_options[_]
   item := config_option.item
   item.type
@@ -776,8 +875,8 @@ lint[output] {
   field := concat(".", [config_option.field, "type"])
   message := sprintf("Config option \"%s\" has an invalid type", [string(item.name)])
   output := {
-    "rule": "config-option-invalid-type",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": message,
     "path": config_file_path,
     "field": field,
@@ -787,6 +886,9 @@ lint[output] {
 
 # Check if repeatable ConfigOption has a template field defined
 lint[output] {
+  rule_name := "repeat-option-missing-template"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   config_option := config_options[_]
   item := config_option.item
   item.repeatable
@@ -794,8 +896,8 @@ lint[output] {
   field := concat(".", [config_option.field, "type"])
   message := sprintf("Repeatable Config option \"%s\" has an incomplete template target", [string(item.name)])
   output := {
-    "rule": "repeat-option-missing-template",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": message,
     "path": config_file_path,
     "field": field,
@@ -805,6 +907,9 @@ lint[output] {
 
 # Check if repeatable ConfigOption has a valuesByGroup field
 lint[output] {
+  rule_name := "repeat-option-missing-valuesByGroup"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   config_option := config_options[_]
   item := config_option.item
   item.repeatable
@@ -812,8 +917,8 @@ lint[output] {
   field := concat(".", [config_option.field, "type"])
   message := sprintf("Repeatable Config option \"%s\" has an incomplete valuesByGroup", [string(item.name)])
   output := {
-    "rule": "repeat-option-missing-valuesByGroup",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": message,
     "path": config_file_path,
     "field": field,
@@ -823,6 +928,9 @@ lint[output] {
 
 # Check if repeatable ConfigOption template ends in array
 lint[output] {
+  rule_name := "repeat-option-malformed-yamlpath"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   config_option := config_options[_]
   item := config_option.item
   item.repeatable
@@ -832,8 +940,8 @@ lint[output] {
   field := concat(".", [config_option.field, "type"])
   message := sprintf("Repeatable Config option \"%s\" yamlPath does not end with an array", [string(item.name)])
   output := {
-    "rule": "repeat-option-malformed-yamlpath",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": message,
     "path": config_file_path,
     "field": field,
@@ -843,6 +951,9 @@ lint[output] {
 
 # Check if ConfigOption should have a "password" type
 lint[output] {
+  rule_name := "config-option-password-type"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
   config_option := config_options[_]
   item := config_option.item
   is_string(item.name)
@@ -851,8 +962,8 @@ lint[output] {
   field := concat(".", [config_option.field, "type"])
   message := sprintf("Config option \"%s\" should have type \"password\"", [item.name])
   output := {
-    "rule": "config-option-password-type",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": message,
     "path": config_file_path,
     "field": field,
@@ -862,6 +973,10 @@ lint[output] {
 
 # Check if all ConfigOptions exist
 lint[output] {
+  rule_name := "config-option-not-found"
+  rule_config := lint_rule_config(rule_name, "warn")
+  not rule_config.off
+
   file := input[_]
 
   expression := "(ConfigOption|ConfigOptionName|ConfigOptionEquals|ConfigOptionNotEquals)\\W+?(repl\\W+?)?([\\w\\d_-]+)"
@@ -873,8 +988,8 @@ lint[output] {
 
   message := sprintf("Config option \"%s\" not found", [option_name])
   output := {
-    "rule": "config-option-not-found",
-    "type": "warn",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": message,
     "path": file.path,
     "docIndex": object.get(file, "docIndex", 0),
@@ -884,6 +999,10 @@ lint[output] {
 
 # Check if ConfigOption is circular (references itself)
 lint[output] {
+  rule_name := "config-option-is-circular"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
+
   config_option := config_options[_]
   item := config_option.item
   value := item[key]
@@ -903,8 +1022,8 @@ lint[output] {
 
   message := sprintf("Config option \"%s\" references itself", [option_name])
   output := {
-    "rule": "config-option-is-circular",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": message,
     "path": config_file_path,
     "field": field,
@@ -914,6 +1033,10 @@ lint[output] {
 
 # Check if sub-templated ConfigOptions are repeatable
 lint[output] {
+  rule_name := "config-option-not-repeatable"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
+
   file := input[_]
 
   expression := "(ConfigOption|ConfigOptionName|ConfigOptionEquals|ConfigOptionNotEquals)\\W+?(repl\\W+?)([\\w\\d_-]+)"
@@ -925,8 +1048,8 @@ lint[output] {
 
   message := sprintf("Config option \"%s\" not repeatable", [option_name])
   output := {
-    "rule": "config-option-not-repeatable",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": message,
     "path": file.path,
     "docIndex": object.get(file, "docIndex", 0),
@@ -943,6 +1066,9 @@ is_when_valid(when) {
   re_match(expression, when)
 }
 lint[output] {
+  rule_name := "config-option-when-is-invalid"
+  rule_config := lint_rule_config(rule_name, "error")
+  not rule_config.off
   config_option := config_options[_]
   item := config_option.item
 
@@ -951,11 +1077,42 @@ lint[output] {
   field := concat(".", [config_option.field, "when"])
 
   output := {
-    "rule": "config-option-when-is-invalid",
-    "type": "error",
+    "rule": rule_name,
+    "type": rule_config.level,
     "message": "Invalid \"when\" expression",
     "path": config_file_path,
     "field": field,
     "docIndex": config_data.docIndex
   }
 }
+
+# Check if LintConfig spec exists
+lintconfig_spec_exists {
+  file := files[_]
+  file.content.kind == "LintConfig"
+  file.content.apiVersion == "kots.io/v1beta1"
+}
+
+# Check if linting rule is ignored
+lint_rule_config(lint_rule_name, default_level) = lint_rule_config {
+  lintconfig_spec_exists
+  lintconfig := files[_].content.spec
+  lint_rule = lintconfig.rules[_]
+  lint_rule.name == lint_rule_name
+  rule_level := validate_lint_rule_level(default_level, lint_rule.level)
+  lint_rule_config := {
+    "off": lint_rule.level == "off",
+    "level": rule_level
+  }
+} else = {
+  "off": false,
+  "level": default_level
+}
+
+# Validate linting rule level, use default if not valid
+validate_lint_rule_level(default_level, input_level) = default_level {
+  input_level != "error"
+  input_level != "warn"
+  input_level != "info"
+  input_level != "off"
+} else = input_level


### PR DESCRIPTION
**Summary of change:**

This allows linting rules to have a configurable level. A rule can be set to show as an `error, warn, info`, or it can be ignored by setting the level to `off`.

LintConfig will have the following definition:
```yaml
apiVersion: kots.io/v1beta1
kind: LintConfig
metadata:
  name: default-lint-config
spec:
  rules:
  - name: preflight-spec
    level: "warn"
  - name: config-spec
    level: "off"
```
Here's the [default lint-config.](https://github.com/replicatedhq/kots-default-yaml/pull/24/files)

**Story:** [SC-59102](https://app.shortcut.com/replicated/story/59102/kots-lintconfig)
