### PR TITLE
add lintconfig schema

### DIFF
--- a/kubernetes_json_schema/schema/v1.23.6-standalone-strict/lintconfig-kots-v1beta1.json
+++ b/kubernetes_json_schema/schema/v1.23.6-standalone-strict/lintconfig-kots-v1beta1.json
@@ -1,0 +1,47 @@
+{
+    "description": "LintConfig is the Schema for the lint config API",
+    "type": "object",
+    "properties": {
+      "apiVersion": {
+        "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+        "type": "string"
+      },
+      "kind": {
+        "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+        "type": "string"
+      },
+      "metadata": {
+        "type": "object"
+      },
+      "spec": {
+        "description": "LintConfigSpec defines the desired state of LintConfig",
+        "type": "object",
+        "required": [
+          "rules"
+        ],
+        "properties": {
+          "rules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "level": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "status": {
+        "description": "LintConfigStatus defines the observed state of LintConfig",
+        "type": "object"
+      }
+    }
+  }


### PR DESCRIPTION
This PR adds the generated schema for the new `LintConfig` kots kind added in [this PR](https://github.com/replicatedhq/kots/pull/3198).