### PR TITLE
update kots app spec schema

### DIFF
--- a/kubernetes_json_schema/schema/v1.23.6-standalone-strict/application-kots-v1beta1.json
+++ b/kubernetes_json_schema/schema/v1.23.6-standalone-strict/application-kots-v1beta1.json
@@ -127,7 +127,13 @@
         "proxyPublicImages": {
           "type": "boolean"
         },
+        "proxyRegistryDomain": {
+          "type": "string"
+        },
         "releaseNotes": {
+          "type": "string"
+        },
+        "replicatedRegistryDomain": {
           "type": "string"
         },
         "requireMinimalRBACPrivileges": {


### PR DESCRIPTION
Updates the kots application spec schema to include the `replicatedRegistryDomain` and `proxyRegistryDomain` fields.