### PR TITLE
Add kURL lint suggestions to kots-lint

### DIFF
--- a/pkg/kots/lint.go
+++ b/pkg/kots/lint.go
@@ -47,6 +47,7 @@ type LintExpression struct {
 	Type      string                       `json:"type"`
 	Message   string                       `json:"message"`
 	Path      string                       `json:"path"`
+	Patch     string                      `json:"patch"`
 	Positions []LintExpressionItemPosition `json:"positions"`
 }
 
@@ -625,8 +626,10 @@ func lintKurlInstaller(linter *kurllint.Linter, specFiles SpecFiles) ([]LintExpr
 					Type:    "error",
 					Path:    file.Path,
 					Message: out.Message,
+					Patch:   out.patch,
 				},
 			)
+			fmt.Print(expressions)
 		}
 	}
 	return expressions, nil

--- a/pkg/kots/lint.go
+++ b/pkg/kots/lint.go
@@ -30,6 +30,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/jsonpath"
+	jsonpatch "github.com/evanphx/json-patch/v5"
 )
 
 var kotsVersions map[string]bool
@@ -47,7 +48,7 @@ type LintExpression struct {
 	Type      string                       `json:"type"`
 	Message   string                       `json:"message"`
 	Path      string                       `json:"path"`
-	Patch     string                      `json:"patch"`
+	Patch     jsonpatch.Patch              `json:"patch"`
 	Positions []LintExpressionItemPosition `json:"positions"`
 }
 

--- a/pkg/kots/lint.go
+++ b/pkg/kots/lint.go
@@ -626,10 +626,9 @@ func lintKurlInstaller(linter *kurllint.Linter, specFiles SpecFiles) ([]LintExpr
 					Type:    "error",
 					Path:    file.Path,
 					Message: out.Message,
-					Patch:   out.patch,
+					Patch:   out.Patch,
 				},
 			)
-			fmt.Print(expressions)
 		}
 	}
 	return expressions, nil


### PR DESCRIPTION
Within kurlkinds we added functionality to send a json patch to fix lint errors/warnings.  This implements this in the kots-lint endpoint so it can be implemented further down the stack in both vendor portal and replicated-lint.