### PR TITLE
Fix single chart path for linting builders releases

### DIFF
--- a/pkg/handlers/builders_lint.go
+++ b/pkg/handlers/builders_lint.go
@@ -75,10 +75,10 @@ func LintBuildersRelease(c *gin.Context) {
 				Type:    "error",
 				Message: err.Error(),
 			})
+		} else {
+			numChartsRendered += 1
+			specFiles = append(specFiles, files...)
 		}
-
-		numChartsRendered += 1
-		specFiles = append(specFiles, files...)
 	} else {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "content type must be application/gzip or application/tar"})
 		return


### PR DESCRIPTION
Applies fix from https://github.com/replicatedhq/kots-lint/pull/168 to single chart linting.