### PR TITLE
Fix fly.io deployment for datadog agent

### DIFF
--- a/dd-fly.toml
+++ b/dd-fly.toml
@@ -27,11 +27,13 @@ kill_timeout = 5
   [[services.ports]]
     force_https = true
     handlers = ["http"]
-    port = 8126
+    start_port = 8126
+    end_port = 8126
 
   [[services.ports]]
     handlers = ["tls", "http"]
-    port = 8126
+    start_port = 8126
+    end_port = 8126
 
   [[services.tcp_checks]]
     grace_period = "30s"


### PR DESCRIPTION
trying to address this error (community post with solution linked in the comment below)

<img width="1603" alt="Screen Shot 2024-02-12 at 9 18 56 AM" src="https://github.com/replicatedhq/kots-lint/assets/1004892/369c7466-309d-4009-8946-65f52e4b17b7">
