### PR TITLE
Bump Go 1.21 to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS builder
+FROM golang:1.22 AS builder
 
 ADD . /go/src/github.com/replicatedhq/kots-lint
 WORKDIR /go/src/github.com/replicatedhq/kots-lint

--- a/okteto.Dockerfile
+++ b/okteto.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 
 EXPOSE 8082
 EXPOSE 2345

--- a/skaffold.Dockerfile
+++ b/skaffold.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS builder
+FROM golang:1.22 AS builder
 
 ADD . /go/src/github.com/replicatedhq/kots-lint
 WORKDIR /go/src/github.com/replicatedhq/kots-lint


### PR DESCRIPTION
https://github.com/replicatedhq/kots-lint/actions/runs/9276065142/job/25522266138#step:5:473

```
0.070 go: go.mod requires go >= 1.22.0 (running go 1.21.10; GOTOOLCHAIN=local)
```