### PR TITLE
update docker images to go 1.24 and bookworm from 1.22 and buster

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -28,6 +28,19 @@ jobs:
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: build-kots-lint
+    if: startsWith(github.ref, 'refs/tags/v') != true # this only runs for non-tag commits
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/build-push-action@v4
+        with:
+          push: false
+          tags: replicated/kots-lint:${{ github.ref_name }}
+
   goreleaser:
     runs-on: ubuntu-latest
     needs: build-kots-lint

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: docker/build-push-action@v4
         with:
           push: false
-          tags: replicated/kots-lint:${{ github.ref_name }}
+          tags: replicated/kots-lint:ci-test
 
   goreleaser:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.24 AS builder
 
 ADD . /go/src/github.com/replicatedhq/kots-lint
 WORKDIR /go/src/github.com/replicatedhq/kots-lint
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/replicatedhq/kots-lint
 RUN make build
 
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update -y && \
     apt-get install -y ca-certificates && \

--- a/skaffold.Dockerfile
+++ b/skaffold.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.24 AS builder
 
 ADD . /go/src/github.com/replicatedhq/kots-lint
 WORKDIR /go/src/github.com/replicatedhq/kots-lint
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/replicatedhq/kots-lint
 RUN make build
 
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ENV DEBUG_MODE on
 


### PR DESCRIPTION
https://github.com/replicatedhq/kots-lint/actions/runs/16452995325/job/46502882667