### PR TITLE
chore: add daily scheduled workflow to update schemas from upstream projects

### DIFF
--- a/.github/workflows/update-schemas.yaml
+++ b/.github/workflows/update-schemas.yaml
@@ -1,0 +1,25 @@
+name: Update Schemas
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # Daily at 8am UTC
+  workflow_dispatch: {}
+
+jobs:
+  update-schemas:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: make schemas
+
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Update schemas from upstream projects"
+          title: "Update schemas from upstream projects"
+          branch: automation/update-schemas
+          body: |
+            Automated schema update from:
+            - [replicatedhq/kotskinds](https://github.com/replicatedhq/kotskinds)
+            - [replicatedhq/embedded-cluster](https://github.com/replicatedhq/embedded-cluster)
+            - [replicatedhq/troubleshoot](https://github.com/replicatedhq/troubleshoot)


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs `make schemas` daily at 8am UTC
- Opens a PR automatically if schemas changed from upstream projects (kotskinds, embedded-cluster, troubleshoot)
- Supports manual trigger via `workflow_dispatch`

Closes https://app.shortcut.com/replicated/story/136517

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Trigger manually via `workflow_dispatch` and confirm it runs `make schemas`
- [ ] Confirm a PR is created when schemas differ from upstream
