### PR TITLE
feat: add helm-lint pass for HelmChart-referenced charts

### DIFF
--- a/app.go
+++ b/app.go
@@ -34,7 +34,7 @@ func main() {
 
 	go daemon.Run()
 
-	term := make(chan os.Signal)
+	term := make(chan os.Signal, 1)
 	signal.Notify(term, syscall.SIGINT, syscall.SIGTERM)
 	<-term
 }

--- a/pkg/kots/helm_chart_lint.go
+++ b/pkg/kots/helm_chart_lint.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/kots-lint/pkg/domain"
 	"github.com/replicatedhq/kotskinds/pkg/helmchart"
-	log "github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -33,11 +32,7 @@ func lintHelmChartsWithHelmLint(renderedFiles domain.SpecFiles, tarGzFiles domai
 	}
 	allKotsHelmCharts := findAllKotsHelmCharts(separated)
 	if len(allKotsHelmCharts) == 0 {
-		log.Debugf("helm-lint: no HelmChart custom resources, skipping helm lint")
 		return lintExpressions, nil
-	}
-	for _, hc := range allKotsHelmCharts {
-		log.Debugf("helm-lint: HelmChart CR %s/%s helmVersion=%q", hc.GetChartName(), hc.GetChartVersion(), hc.GetHelmVersion())
 	}
 
 	for _, tarGzFile := range tarGzFiles {
@@ -48,27 +43,22 @@ func lintHelmChartsWithHelmLint(renderedFiles domain.SpecFiles, tarGzFiles domai
 		content := []byte(tarGzFile.Content)
 		ch, err := loader.LoadArchive(bytes.NewReader(content))
 		if err != nil {
-			log.Debugf("helm-lint: failed to load chart archive %s: %v", tarGzFile.Path, err)
 			continue
 		}
-		log.Debugf("helm-lint: loaded archive %s as chart %s/%s", tarGzFile.Path, ch.Name(), ch.Metadata.Version)
 
 		matched := matchHelmChartCR(ch, allKotsHelmCharts)
 		if matched == nil {
 			// No matching kots HelmChart CR — that case is reported by lintHelmCharts.
-			log.Debugf("helm-lint: no matching HelmChart CR for archive %s (%s/%s), skipping", tarGzFile.Path, ch.Name(), ch.Metadata.Version)
 			continue
 		}
 
 		// Only lint Helm v3 (and later) charts. Skip explicit v2 HelmChart CRs.
 		if v := matched.GetHelmVersion(); v != "" && v != "v3" {
-			log.Infof("helm-lint: skipping chart %s/%s, helmVersion=%q is not v3", ch.Name(), ch.Metadata.Version, v)
 			continue
 		}
 
 		builderValues, err := matched.GetBuilderValues()
 		if err != nil {
-			log.Warnf("helm-lint: failed to evaluate spec.builder for %s/%s: %v", ch.Name(), ch.Metadata.Version, err)
 			lintExpressions = append(lintExpressions, domain.LintExpression{
 				Rule:    "helm-schema-violation",
 				Type:    "warn",
@@ -82,7 +72,6 @@ func lintHelmChartsWithHelmLint(renderedFiles domain.SpecFiles, tarGzFiles domai
 		// HelmChart spec.builder overrides so helm lint sees both.
 		merged, err := chartutil.CoalesceValues(ch, builderValues)
 		if err != nil {
-			log.Warnf("helm-lint: failed to merge builder and default values for %s/%s: %v", ch.Name(), ch.Metadata.Version, err)
 			lintExpressions = append(lintExpressions, domain.LintExpression{
 				Rule:    "helm-schema-violation",
 				Type:    "warn",
@@ -92,16 +81,13 @@ func lintHelmChartsWithHelmLint(renderedFiles domain.SpecFiles, tarGzFiles domai
 			continue
 		}
 
-		log.Infof("helm-lint: running helm lint on %s (%s/%s) with %d top-level value key(s)", tarGzFile.Path, ch.Name(), ch.Metadata.Version, len(merged.AsMap()))
 		chartLintExpressions, err := runHelmLintOnArchive(content, tarGzFile.Path, merged.AsMap())
 		if err != nil {
 			return nil, errors.Wrapf(err, "helm lint chart %s", tarGzFile.Path)
 		}
-		log.Infof("helm-lint: %s produced %d lint expression(s)", tarGzFile.Path, len(chartLintExpressions))
 		lintExpressions = append(lintExpressions, chartLintExpressions...)
 	}
 
-	log.Infof("helm-lint: complete, %d total lint expression(s)", len(lintExpressions))
 	return lintExpressions, nil
 }
 
@@ -135,19 +121,6 @@ func runHelmLintOnArchive(archive []byte, chartPath string, values map[string]in
 
 	linter := action.NewLint()
 	result := linter.Run([]string{tgzPath}, values)
-	if result != nil {
-		log.Debugf("helm-lint: %s helm-action result charts=%d messages=%d errors=%d", chartPath, result.TotalChartsLinted, len(result.Messages), len(result.Errors))
-		for _, m := range result.Messages {
-			if m.Err != nil {
-				log.Debugf("helm-lint: %s [sev=%d] %s: %s", chartPath, m.Severity, m.Path, m.Err.Error())
-			}
-		}
-		for _, e := range result.Errors {
-			if e != nil {
-				log.Debugf("helm-lint: %s top-level error: %s", chartPath, e.Error())
-			}
-		}
-	}
 
 	return helmLintResultToLintExpressions(result, chartPath), nil
 }

--- a/pkg/kots/helm_chart_lint.go
+++ b/pkg/kots/helm_chart_lint.go
@@ -2,6 +2,7 @@ package kots
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +41,12 @@ func lintHelmChartsWithHelmLint(renderedFiles domain.SpecFiles, tarGzFiles domai
 			continue
 		}
 
-		content := []byte(tarGzFile.Content)
+		// Tar archives may be base64-encoded (JSON transport) or raw bytes (tar
+		// stream transport). Match domain.SpecFilesFromTarGz's fallback.
+		content, err := base64.StdEncoding.DecodeString(tarGzFile.Content)
+		if err != nil {
+			content = []byte(tarGzFile.Content)
+		}
 		ch, err := loader.LoadArchive(bytes.NewReader(content))
 		if err != nil {
 			continue

--- a/pkg/kots/helm_chart_lint.go
+++ b/pkg/kots/helm_chart_lint.go
@@ -1,0 +1,261 @@
+package kots
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots-lint/pkg/domain"
+	"github.com/replicatedhq/kotskinds/pkg/helmchart"
+	log "github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/lint/support"
+)
+
+// lintHelmChartsWithHelmLint runs `helm lint` against each helm chart archive that
+// is referenced by a kots HelmChart custom resource, using the HelmChart's
+// `spec.builder` values. Lint findings are reported as helm-schema-violation rules.
+//
+// renderedFiles are the rendered KOTS spec files (used to find HelmChart CRs and
+// extract builder values). tarGzFiles are the helm chart archives in the release.
+func lintHelmChartsWithHelmLint(renderedFiles domain.SpecFiles, tarGzFiles domain.SpecFiles) ([]domain.LintExpression, error) {
+	lintExpressions := []domain.LintExpression{}
+
+	separated, err := renderedFiles.Separate()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to separate multi docs")
+	}
+	allKotsHelmCharts := findAllKotsHelmCharts(separated)
+	if len(allKotsHelmCharts) == 0 {
+		log.Debugf("helm-lint: no HelmChart custom resources, skipping helm lint")
+		return lintExpressions, nil
+	}
+	for _, hc := range allKotsHelmCharts {
+		log.Debugf("helm-lint: HelmChart CR %s/%s helmVersion=%q", hc.GetChartName(), hc.GetChartVersion(), hc.GetHelmVersion())
+	}
+
+	for _, tarGzFile := range tarGzFiles {
+		if !tarGzFile.IsTarGz() {
+			continue
+		}
+
+		content := []byte(tarGzFile.Content)
+		ch, err := loader.LoadArchive(bytes.NewReader(content))
+		if err != nil {
+			log.Debugf("helm-lint: failed to load chart archive %s: %v", tarGzFile.Path, err)
+			continue
+		}
+		log.Debugf("helm-lint: loaded archive %s as chart %s/%s", tarGzFile.Path, ch.Name(), ch.Metadata.Version)
+
+		matched := matchHelmChartCR(ch, allKotsHelmCharts)
+		if matched == nil {
+			// No matching kots HelmChart CR — that case is reported by lintHelmCharts.
+			log.Debugf("helm-lint: no matching HelmChart CR for archive %s (%s/%s), skipping", tarGzFile.Path, ch.Name(), ch.Metadata.Version)
+			continue
+		}
+
+		// Only lint Helm v3 (and later) charts. Skip explicit v2 HelmChart CRs.
+		if v := matched.GetHelmVersion(); v != "" && v != "v3" {
+			log.Infof("helm-lint: skipping chart %s/%s, helmVersion=%q is not v3", ch.Name(), ch.Metadata.Version, v)
+			continue
+		}
+
+		builderValues, err := matched.GetBuilderValues()
+		if err != nil {
+			log.Warnf("helm-lint: failed to evaluate spec.builder for %s/%s: %v", ch.Name(), ch.Metadata.Version, err)
+			lintExpressions = append(lintExpressions, domain.LintExpression{
+				Rule:    "helm-schema-violation",
+				Type:    "warn",
+				Path:    tarGzFile.Path,
+				Message: fmt.Sprintf("Failed to evaluate spec.builder values for chart %q: %v", ch.Name(), err),
+			})
+			continue
+		}
+
+		// Merge the chart's default values (values.yaml + dependency defaults) with the
+		// HelmChart spec.builder overrides so helm lint sees both.
+		merged, err := chartutil.CoalesceValues(ch, builderValues)
+		if err != nil {
+			log.Warnf("helm-lint: failed to merge builder and default values for %s/%s: %v", ch.Name(), ch.Metadata.Version, err)
+			lintExpressions = append(lintExpressions, domain.LintExpression{
+				Rule:    "helm-schema-violation",
+				Type:    "warn",
+				Path:    tarGzFile.Path,
+				Message: fmt.Sprintf("Failed to merge builder and default values for chart %q: %v", ch.Name(), err),
+			})
+			continue
+		}
+
+		log.Infof("helm-lint: running helm lint on %s (%s/%s) with %d top-level value key(s)", tarGzFile.Path, ch.Name(), ch.Metadata.Version, len(merged.AsMap()))
+		chartLintExpressions, err := runHelmLintOnArchive(content, tarGzFile.Path, merged.AsMap())
+		if err != nil {
+			return nil, errors.Wrapf(err, "helm lint chart %s", tarGzFile.Path)
+		}
+		log.Infof("helm-lint: %s produced %d lint expression(s)", tarGzFile.Path, len(chartLintExpressions))
+		lintExpressions = append(lintExpressions, chartLintExpressions...)
+	}
+
+	log.Infof("helm-lint: complete, %d total lint expression(s)", len(lintExpressions))
+	return lintExpressions, nil
+}
+
+// matchHelmChartCR returns the HelmChart CR whose chart name and version match
+// the metadata in the chart archive, or nil if none match.
+func matchHelmChartCR(ch *chart.Chart, helmCharts []helmchart.HelmChartInterface) helmchart.HelmChartInterface {
+	if ch.Metadata == nil {
+		return nil
+	}
+	for _, hc := range helmCharts {
+		if hc.GetChartName() == ch.Metadata.Name && hc.GetChartVersion() == ch.Metadata.Version {
+			return hc
+		}
+	}
+	return nil
+}
+
+// runHelmLintOnArchive extracts the chart archive bytes to a temp dir and runs
+// `helm lint` against it with the supplied values.
+func runHelmLintOnArchive(archive []byte, chartPath string, values map[string]interface{}) ([]domain.LintExpression, error) {
+	tempDir, err := os.MkdirTemp("", "kots-lint-helm-")
+	if err != nil {
+		return nil, errors.Wrap(err, "create temp dir")
+	}
+	defer os.RemoveAll(tempDir)
+
+	tgzPath := filepath.Join(tempDir, "chart.tgz")
+	if err := os.WriteFile(tgzPath, archive, 0644); err != nil {
+		return nil, errors.Wrap(err, "write chart archive")
+	}
+
+	linter := action.NewLint()
+	result := linter.Run([]string{tgzPath}, values)
+	if result != nil {
+		log.Debugf("helm-lint: %s helm-action result charts=%d messages=%d errors=%d", chartPath, result.TotalChartsLinted, len(result.Messages), len(result.Errors))
+		for _, m := range result.Messages {
+			if m.Err != nil {
+				log.Debugf("helm-lint: %s [sev=%d] %s: %s", chartPath, m.Severity, m.Path, m.Err.Error())
+			}
+		}
+		for _, e := range result.Errors {
+			if e != nil {
+				log.Debugf("helm-lint: %s top-level error: %s", chartPath, e.Error())
+			}
+		}
+	}
+
+	return helmLintResultToLintExpressions(result, chartPath), nil
+}
+
+// helmLintResultToLintExpressions converts helm lint messages and any top-level
+// errors into kots-lint expressions under the helm-schema-violation rule.
+func helmLintResultToLintExpressions(result *action.LintResult, chartPath string) []domain.LintExpression {
+	expressions := []domain.LintExpression{}
+	if result == nil {
+		return expressions
+	}
+
+	// Errors returned outside of Messages typically indicate the chart could not be
+	// loaded at all (missing Chart.yaml, etc.). The per-message errors are already
+	// included in result.Messages, so we only surface non-message-level errors here
+	// to avoid duplicates.
+	seenErrors := map[string]bool{}
+	for _, m := range result.Messages {
+		if m.Err != nil {
+			seenErrors[m.Err.Error()] = true
+		}
+	}
+	for _, err := range result.Errors {
+		if err == nil {
+			continue
+		}
+		if seenErrors[err.Error()] {
+			continue
+		}
+		for _, finding := range splitHelmLintMessage(err.Error()) {
+			expressions = append(expressions, domain.LintExpression{
+				Rule:    "helm-schema-violation",
+				Type:    "error",
+				Path:    chartPath,
+				Message: finding,
+			})
+		}
+	}
+
+	for _, msg := range result.Messages {
+		if msg.Err == nil {
+			continue
+		}
+		t := helmSeverityToLintType(msg.Severity)
+		if t == "" {
+			continue
+		}
+		prefix := ""
+		if msg.Path != "" && msg.Path != "." {
+			prefix = msg.Path + ": "
+		}
+		for _, finding := range splitHelmLintMessage(msg.Err.Error()) {
+			expressions = append(expressions, domain.LintExpression{
+				Rule:    "helm-schema-violation",
+				Type:    t,
+				Path:    chartPath,
+				Message: prefix + finding,
+			})
+		}
+	}
+
+	return expressions
+}
+
+// splitHelmLintMessage splits a helm schema validation error message into one
+// string per top-level finding. Helm's jsonschema validation collects every
+// violation into a single multi-line error: each top-level violation begins on
+// a new line with `- at '/...': `, and may be followed by indented children.
+// We keep each top-level violation (with its indented children) together while
+// preserving any preamble (e.g. "values.yaml:" or chart name) on every finding
+// so context is not lost.
+func splitHelmLintMessage(text string) []string {
+	const marker = "- at "
+	idx := strings.Index(text, marker)
+	if idx < 0 {
+		return []string{strings.TrimRight(text, "\n")}
+	}
+	preamble := strings.TrimRight(text[:idx], " :\n\t")
+	body := text[idx:]
+	parts := strings.Split(body, "\n"+marker)
+	findings := make([]string, 0, len(parts))
+	for i, p := range parts {
+		if i > 0 {
+			p = marker + p
+		}
+		p = strings.TrimRight(p, "\n")
+		if p == "" {
+			continue
+		}
+		if preamble != "" {
+			p = preamble + ": " + p
+		}
+		findings = append(findings, p)
+	}
+	if len(findings) == 0 {
+		return []string{strings.TrimRight(text, "\n")}
+	}
+	return findings
+}
+
+func helmSeverityToLintType(sev int) string {
+	switch sev {
+	case support.ErrorSev:
+		return "error"
+	case support.WarningSev:
+		return "warn"
+	default:
+		// Info and Unknown severities are not surfaced as lint expressions.
+		return ""
+	}
+}

--- a/pkg/kots/helm_chart_lint_test.go
+++ b/pkg/kots/helm_chart_lint_test.go
@@ -1,0 +1,241 @@
+package kots
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/replicatedhq/kots-lint/pkg/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_splitHelmLintMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "no findings returns single entry",
+			input:    "some other helm error",
+			expected: []string{"some other helm error"},
+		},
+		{
+			name:  "single top-level finding with preamble",
+			input: "values.yaml: - at '/seed': missing property 'resources'",
+			expected: []string{
+				"values.yaml: - at '/seed': missing property 'resources'",
+			},
+		},
+		{
+			name: "multiple top-level findings split, preamble preserved",
+			input: "values.yaml: - at '/seed': missing property 'resources'\n" +
+				"- at '/worker': missing properties 'livenessProbe', 'readinessProbe'\n",
+			expected: []string{
+				"values.yaml: - at '/seed': missing property 'resources'",
+				"values.yaml: - at '/worker': missing properties 'livenessProbe', 'readinessProbe'",
+			},
+		},
+		{
+			name: "nested children stay with their parent",
+			input: "values.yaml: - at '/ingress': validation failed\n" +
+				"  - at '/ingress': missing property 'certManager'\n" +
+				"  - at '/ingress/tls': missing property 'secretName'\n" +
+				"- at '/web': missing property 'service'\n",
+			expected: []string{
+				"values.yaml: - at '/ingress': validation failed\n" +
+					"  - at '/ingress': missing property 'certManager'\n" +
+					"  - at '/ingress/tls': missing property 'secretName'",
+				"values.yaml: - at '/web': missing property 'service'",
+			},
+		},
+		{
+			name: "multi-line preamble preserved",
+			input: "templates/: values don't meet the specifications of the schema(s) in the following chart(s):\n" +
+				"vendorflow:\n" +
+				"- at '/seed': missing property 'resources'\n" +
+				"- at '/api': missing properties 'service'\n",
+			expected: []string{
+				"templates/: values don't meet the specifications of the schema(s) in the following chart(s):\nvendorflow: - at '/seed': missing property 'resources'",
+				"templates/: values don't meet the specifications of the schema(s) in the following chart(s):\nvendorflow: - at '/api': missing properties 'service'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitHelmLintMessage(tt.input)
+			assert.Equal(t, tt.expected, got, "input:\n%s", tt.input)
+			for _, f := range got {
+				assert.False(t, strings.HasSuffix(f, "\n"), "finding should not end with newline: %q", f)
+			}
+		})
+	}
+}
+
+const helmChartCRWithBuilder = `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: testchart
+spec:
+  chart:
+    name: testchart
+    chartVersion: 0.1.0
+  builder:
+    image:
+      repository: nginx
+      tag: stable
+`
+
+// chart whose templates fail to render unless `image.repository` is set as a string.
+const requireValueChart = `apiVersion: v2
+name: testchart
+version: 0.1.0
+`
+const requireValueDeployment = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: {{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag }}
+`
+
+func Test_lintHelmChartsWithHelmLint(t *testing.T) {
+	tests := []struct {
+		name              string
+		archive           []tarChartFile
+		archivePath       string
+		helmChartCR       string
+		expectExpressions int
+		expectRule        string
+	}{
+		{
+			name: "valid chart with builder values produces no errors",
+			archive: []tarChartFile{
+				chartFile("testchart/Chart.yaml", requireValueChart),
+				chartFile("testchart/templates/deployment.yaml", requireValueDeployment),
+			},
+			archivePath:       "testchart-0.1.0.tar.gz",
+			helmChartCR:       helmChartCRWithBuilder,
+			expectExpressions: 0,
+		},
+		{
+			name: "chart with no matching HelmChart CR is skipped",
+			archive: []tarChartFile{
+				chartFile("testchart/Chart.yaml", requireValueChart),
+				chartFile("testchart/templates/deployment.yaml", requireValueDeployment),
+			},
+			archivePath:       "testchart-0.1.0.tar.gz",
+			helmChartCR:       "", // no HelmChart CR at all
+			expectExpressions: 0,
+		},
+		{
+			name: "chart default values from values.yaml are merged with builder values",
+			archive: []tarChartFile{
+				chartFile("testchart/Chart.yaml", requireValueChart),
+				chartFile("testchart/values.yaml", "image:\n  repository: nginx\n"),
+				chartFile("testchart/templates/deployment.yaml", requireValueDeployment),
+			},
+			archivePath: "testchart-0.1.0.tar.gz",
+			// Builder only sets tag; repository must come from chart defaults.
+			helmChartCR: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: testchart
+spec:
+  chart:
+    name: testchart
+    chartVersion: 0.1.0
+  builder:
+    image:
+      tag: stable
+`,
+			expectExpressions: 0,
+		},
+		{
+			name: "helm v2 HelmChart CR is skipped",
+			archive: []tarChartFile{
+				chartFile("testchart/Chart.yaml", requireValueChart),
+				chartFile("testchart/templates/deployment.yaml", requireValueDeployment),
+			},
+			archivePath: "testchart-0.1.0.tar.gz",
+			helmChartCR: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: testchart
+spec:
+  chart:
+    name: testchart
+    chartVersion: 0.1.0
+  helmVersion: v2
+`,
+			expectExpressions: 0,
+		},
+		{
+			name: "chart that fails template rendering produces helm-schema-violation",
+			archive: []tarChartFile{
+				chartFile("testchart/Chart.yaml", requireValueChart),
+				chartFile("testchart/templates/deployment.yaml", requireValueDeployment),
+			},
+			archivePath: "testchart-0.1.0.tar.gz",
+			// HelmChart CR with no builder values, so `required` fails.
+			helmChartCR: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: testchart
+spec:
+  chart:
+    name: testchart
+    chartVersion: 0.1.0
+`,
+			expectExpressions: 1,
+			expectRule:        "helm-schema-violation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tarGzFiles := domain.SpecFiles{
+				{
+					Name:    tt.archivePath,
+					Path:    tt.archivePath,
+					Content: buildChartArchive(t, tt.archive),
+				},
+			}
+
+			renderedFiles := domain.SpecFiles{}
+			if tt.helmChartCR != "" {
+				renderedFiles = append(renderedFiles, domain.SpecFile{
+					Name:    "helmchart.yaml",
+					Path:    "helmchart.yaml",
+					Content: tt.helmChartCR,
+				})
+			}
+
+			expressions, err := lintHelmChartsWithHelmLint(renderedFiles, tarGzFiles)
+			require.NoError(t, err)
+
+			if tt.expectExpressions == 0 {
+				assert.Empty(t, expressions)
+				return
+			}
+
+			assert.GreaterOrEqual(t, len(expressions), tt.expectExpressions)
+			for _, e := range expressions {
+				assert.Equal(t, tt.expectRule, e.Rule)
+				assert.Equal(t, tt.archivePath, e.Path)
+			}
+		})
+	}
+}

--- a/pkg/kots/lint.go
+++ b/pkg/kots/lint.go
@@ -134,10 +134,11 @@ func LintSpecFiles(ctx context.Context, specFiles domain.SpecFiles) ([]domain.Li
 	}
 
 	for _, tarGtarGzFile := range tarGzFiles {
+		// Tar archives may be base64-encoded (JSON transport) or raw bytes (tar
+		// stream transport). Match domain.SpecFilesFromTarGz's fallback.
 		content, err := base64.StdEncoding.DecodeString(tarGtarGzFile.Content)
 		if err != nil {
-			log.Debugf("failed to base64 decode tarGz content: %v", err)
-			continue
+			content = []byte(tarGtarGzFile.Content)
 		}
 
 		files, err := GetFilesFromChartReader(ctx, bytes.NewReader(content))
@@ -249,6 +250,11 @@ func LintSpecFiles(ctx context.Context, specFiles domain.SpecFiles) ([]domain.Li
 		return nil, false, errors.Wrap(err, "failed to lint chart troubleshoot specs")
 	}
 
+	helmChartSchemaLintExpressions, err := lintHelmChartsWithHelmLint(renderedFiles, tarGzFiles)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "failed to lint helm charts with helm lint")
+	}
+
 	allLintExpressions := []domain.LintExpression{}
 	allLintExpressions = append(allLintExpressions, yamlLintExpressions...)
 	allLintExpressions = append(allLintExpressions, opaNonRenderedLintExpressions...)
@@ -258,6 +264,7 @@ func LintSpecFiles(ctx context.Context, specFiles domain.SpecFiles) ([]domain.Li
 	allLintExpressions = append(allLintExpressions, installerLintExpressions...)
 	allLintExpressions = append(allLintExpressions, embeddedClusterLintExpressions...)
 	allLintExpressions = append(allLintExpressions, chartTroubleshootLintExpressions...)
+	allLintExpressions = append(allLintExpressions, helmChartSchemaLintExpressions...)
 
 	return allLintExpressions, true, nil
 }

--- a/pkg/kots/troubleshoot_chart_lint.go
+++ b/pkg/kots/troubleshoot_chart_lint.go
@@ -37,10 +37,11 @@ func lintHelmChartTroubleshootCRDs(ctx context.Context, tarGzFiles domain.SpecFi
 			continue
 		}
 
+		// Tar archives may be base64-encoded (JSON transport) or raw bytes (tar
+		// stream transport). Match domain.SpecFilesFromTarGz's fallback.
 		content, err := base64.StdEncoding.DecodeString(tarGzFile.Content)
 		if err != nil {
-			log.Debugf("failed to base64 decode tarGz content: %v", err)
-			continue
+			content = []byte(tarGzFile.Content)
 		}
 
 		ch, err := loader.LoadArchive(bytes.NewReader(content))


### PR DESCRIPTION
## Summary

- Add `helm lint` pass for chart archives referenced by a kots `HelmChart` CR, using merged chart defaults + `spec.builder` values. Findings are reported under a new `helm-schema-violation` rule.
- Split helm's jsonschema validation errors into one lint expression per top-level `- at '/...'` finding (nested children stay grouped with their parent; file/chart preamble preserved on every entry)
instead of one giant multi-violation message.
- Accept raw (non-base64) tar.gz content in `LintSpecFiles` and `lintHelmChartTroubleshootCRDs`, matching `domain.SpecFilesFromTarGz`'s fallback.
- Skip helm-lint for `HelmChart` CRs explicitly pinned to `helmVersion: v2`.
- Buffer the SIGINT/SIGTERM channel in `main` so signals aren't dropped by `signal.Notify`.
- Add unit tests for the message splitter and the helm-lint integration paths.

Example run
```sh
tar cvf - out | curl -H "content-type: application/tar" -XPOST --data-binary @- http://localhost:8082/v1/lint | jq
{
  "lintExpressions": [
    {
      "rule": "may-contain-secrets",
      "type": "info",
      "message": "It looks like there might be secrets in this file",
      "path": "out/vendorflow-chart.yaml",
      "positions": [
        {
          "start": {
            "line": 139
          }
        }
      ]
    },
    {
      "rule": "troubleshoot-spec",
      "type": "warn",
      "message": "Missing troubleshoot spec",
      "path": "",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "values.yaml: - at '/api': missing properties 'service', 'livenessProbe', 'readinessProbe'",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "values.yaml: - at '/seed': missing property 'resources'",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "values.yaml: - at '/web': missing property 'service'",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "values.yaml: - at '/ingress': validation failed\n  - at '/ingress': missing property 'certManager'\n  - at '/ingress/tls': missing property 'secretName'\n  - at '/ingress/annotations': missing property 'traefik.ingress.kubernetes.io/router.entrypoints'",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "values.yaml: - at '': additional properties 'namespace', 'session', 'replicated' not allowed",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "templates/: values don't meet the specifications of the schema(s) in the following chart(s):\nvendorflow: - at '/traefik': validation failed\n  - at '/traefik/ports': validation failed\n    - at '/traefik/ports/web': validation failed\n      - at '/traefik/ports/web/nodePort': got null, want integer\n      - at '/traefik/ports/web': additional properties 'targetPort', 'observability', 'proxyProtocol', 'forwardedHeaders', 'protocol', 'exposedPort', 'asDefault', 'expose', 'http', 'transport' not allowed\n    - at '/traefik/ports/websecure': validation failed\n      - at '/traefik/ports/websecure/nodePort': got null, want integer\n      - at '/traefik/ports/websecure': additional properties 'transport', 'containerPort', 'http', 'exposedPort', 'proxyProtocol', 'allowACMEByPass', 'forwardedHeaders', 'expose', 'http3', 'protocol', 'appProtocol', 'hostPort', 'observability', 'targetPort' not allowed\n    - at '/traefik/ports': additional properties 'metrics', 'traefik' not allowed\n  - at '/traefik/service': additional properties 'labels', 'spec', 'loadBalancerSourceRanges', 'annotationsUDP', 'additionalServices', 'externalIPs', 'enabled', 'annotations', 'annotationsTCP', 'single' not allowed\n  - at '/traefik': additional properties 'nodeSelector', 'hostNetwork', 'podDisruptionBudget', 'autoscaling', 'api', 'ingressRoute', 'resources', 'ocsp', 'additionalVolumeMounts', 'topologySpreadConstraints', 'updateStrategy', 'logs', 'livenessProbe', 'namespaceOverride', 'rbac', 'instanceLabelOverride', 'startupProbe', 'securityContext', 'serviceAccountAnnotations', 'global', 'versionOverride', 'gateway', 'nameOverride', 'tolerations', 'oci_meta', 'affinity', 'tlsOptions', 'extraObjects', 'serviceAccount', 'offering_version', 'volumes', 'gatewayClass', 'image', 'priorityClassName', 'fullnameOverride', 'deployment', 'certificatesResolvers', 'envFrom', 'metrics', 'podSecurityContext', 'env', 'hub', 'experimental', 'providers', 'tracing', 'additionalArguments', 'tlsStore', 'persistence', 'readinessProbe', 'commonLabels', 'podSecurityPolicy', 'core', 'ingressClass' not allowed",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "templates/: values don't meet the specifications of the schema(s) in the following chart(s):\nvendorflow: - at '/web': missing property 'service'",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "templates/: values don't meet the specifications of the schema(s) in the following chart(s):\nvendorflow: - at '/notifications': validation failed\n  - at '/notifications/email': missing properties 'smtpHost', 'smtpPort', 'from', 'to'\n  - at '/notifications/slack': missing property 'webhookURL'",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "templates/: values don't meet the specifications of the schema(s) in the following chart(s):\nvendorflow: - at '/ingress': validation failed\n  - at '/ingress': missing property 'certManager'\n  - at '/ingress/tls': missing property 'secretName'\n  - at '/ingress/annotations': missing property 'traefik.ingress.kubernetes.io/router.entrypoints'",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    },
    {
      "rule": "helm-schema-violation",
      "type": "error",
      "message": "templates/: values don't meet the specifications of the schema(s) in the following chart(s):\nvendorflow: - at '/seed': missing property 'resources'",
      "path": "out/vendorflow-0.6.7.tgz",
      "positions": null
    }
  ],
  "isLintingComplete": true
}
```
