### PR TITLE
Add Helm CLI install type lint validation

### DIFF
--- a/pkg/kots/helm_install_lint.go
+++ b/pkg/kots/helm_install_lint.go
@@ -26,6 +26,7 @@ var replicatedKubernetesAPIVersions = map[string]bool{
 	"kots.io/v1beta1":                        true,
 	"kots.io/v1beta2":                        true,
 	"troubleshoot.sh/v1beta2":                true,
+	"troubleshoot.sh/v1beta3":                true,
 	"velero.io/v1":                           true,
 }
 

--- a/pkg/kots/helm_install_lint.go
+++ b/pkg/kots/helm_install_lint.go
@@ -18,12 +18,15 @@ type helmInstallDoc struct {
 	} `yaml:"metadata"`
 }
 
+// https://docs.replicated.com/reference/custom-resource-about
 var replicatedKubernetesAPIVersions = map[string]bool{
+	"app.k8s.io/v1beta1":                     true,
 	"embeddedcluster.replicated.com/v1beta1": true,
 	"cluster.kurl.sh/v1beta1":                true,
 	"kots.io/v1beta1":                        true,
 	"kots.io/v1beta2":                        true,
 	"troubleshoot.sh/v1beta2":                true,
+	"velero.io/v1":                           true,
 }
 
 // lintHelmInstallType checks the requirements for Helm CLI install types, that are
@@ -72,7 +75,7 @@ func lintHelmInstallType(ctx context.Context, specFiles domain.SpecFiles) ([]dom
 			Rule:    "helm-install-type-missing-annotation",
 			Type:    "error",
 			Path:    spec.Path,
-			Message: fmt.Sprintf("%s %s is missing the required kots.io/installer-only annotation for Helm install type", doc.APIVersion, doc.Kind),
+			Message: fmt.Sprintf("%s are raw Kubernetes resources without the kots.io/installer-only annotation. Add this annotation to the resource or remove it to enable Helm CLI install.", spec.Path),
 		})
 	}
 

--- a/pkg/kots/helm_install_lint.go
+++ b/pkg/kots/helm_install_lint.go
@@ -1,0 +1,85 @@
+package kots
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/kots-lint/pkg/domain"
+	"gopkg.in/yaml.v2"
+)
+
+type helmInstallDoc struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Annotations map[string]string `yaml:"annotations"`
+	} `yaml:"metadata"`
+}
+
+var replicatedKubernetesAPIVersions = map[string]bool{
+	"embeddedcluster.replicated.com/v1beta1": true,
+	"cluster.kurl.sh/v1beta1":                true,
+	"kots.io/v1beta1":                        true,
+	"kots.io/v1beta2":                        true,
+	"troubleshoot.sh/v1beta2":                true,
+}
+
+// lintHelmInstallType checks the requirements for Helm CLI install types, that are
+// - must have HelmChart CR and chart tgz (already checked by lintHelmCharts)
+// - any non Replicated Kubernetes resources must include the kots.io/installer-only annotation.
+func lintHelmInstallType(ctx context.Context, specFiles domain.SpecFiles) ([]domain.LintExpression, error) {
+	lintExpressions := []domain.LintExpression{}
+
+	separatedSpecFiles, err := specFiles.Separate()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to separate multi docs")
+	}
+
+	for _, spec := range separatedSpecFiles {
+		// stop early if the caller cancelled or the deadline passed
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		// only check files in the root directory of the release
+		if !isInRootDir(spec.Path) {
+			continue
+		}
+
+		var doc helmInstallDoc
+		if err := yaml.Unmarshal([]byte(spec.Content), &doc); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal spec content")
+		}
+
+		// Separate() can emit empty docs (e.g. a trailing `---`); skip them.
+		if doc.APIVersion == "" && doc.Kind == "" {
+			continue
+		}
+
+		// Helm CLI install can include Replicated custom resources
+		if replicatedKubernetesAPIVersions[doc.APIVersion] {
+			continue
+		}
+
+		// All other Kubernetes resources must be annotated with kots.io/installer-only
+		if _, ok := doc.Metadata.Annotations["kots.io/installer-only"]; ok {
+			continue
+		}
+
+		lintExpressions = append(lintExpressions, domain.LintExpression{
+			Rule:    "helm-install-type-missing-annotation",
+			Type:    "error",
+			Path:    spec.Path,
+			Message: fmt.Sprintf("%s %s is missing the required kots.io/installer-only annotation for Helm install type", doc.APIVersion, doc.Kind),
+		})
+	}
+
+	return lintExpressions, nil
+}
+
+// isInRootDir checks if the file is a file in root directory of Replicated release
+func isInRootDir(path string) bool {
+	return strings.Count(path, "/") <= 1
+}

--- a/pkg/kots/helm_install_lint.go
+++ b/pkg/kots/helm_install_lint.go
@@ -40,6 +40,12 @@ func lintHelmInstallType(ctx context.Context, specFiles domain.SpecFiles) ([]dom
 		return nil, errors.Wrap(err, "failed to separate multi docs")
 	}
 
+	// no lint if there's no HelmChart CR
+	allKotsHelmCharts := findAllKotsHelmCharts(separatedSpecFiles)
+	if len(allKotsHelmCharts) == 0 {
+		return lintExpressions, nil
+	}
+
 	for _, spec := range separatedSpecFiles {
 		// stop early if the caller cancelled or the deadline passed
 		if err := ctx.Err(); err != nil {

--- a/pkg/kots/helm_install_lint.go
+++ b/pkg/kots/helm_install_lint.go
@@ -73,7 +73,7 @@ func lintHelmInstallType(ctx context.Context, specFiles domain.SpecFiles) ([]dom
 
 		lintExpressions = append(lintExpressions, domain.LintExpression{
 			Rule:    "helm-install-type-missing-annotation",
-			Type:    "error",
+			Type:    "warn",
 			Path:    spec.Path,
 			Message: fmt.Sprintf("%s are raw Kubernetes resources without the kots.io/installer-only annotation. Add this annotation to the resource or remove it to enable Helm CLI install.", spec.Path),
 		})

--- a/pkg/kots/helm_install_lint.go
+++ b/pkg/kots/helm_install_lint.go
@@ -75,7 +75,7 @@ func lintHelmInstallType(ctx context.Context, specFiles domain.SpecFiles) ([]dom
 			Rule:    "helm-install-type-missing-annotation",
 			Type:    "warn",
 			Path:    spec.Path,
-			Message: fmt.Sprintf("%s are raw Kubernetes resources without the kots.io/installer-only annotation. Add this annotation to the resource or remove it to enable Helm CLI install.", spec.Path),
+			Message: fmt.Sprintf("%s is a raw Kubernetes resource without the kots.io/installer-only annotation. Add this annotation to the resource or remove it to enable Helm CLI install.", spec.Path),
 		})
 	}
 

--- a/pkg/kots/helm_install_lint_test.go
+++ b/pkg/kots/helm_install_lint_test.go
@@ -87,6 +87,19 @@ metadata:
 			name: "resource without annotation returns lint error",
 			specFiles: domain.SpecFiles{
 				{
+					Name: "helmchart.yaml",
+					Path: "helmchart.yaml",
+					Content: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: mychart
+spec:
+  chart:
+    name: mychart
+    chartVersion: 1.0.0
+`,
+				},
+				{
 					Name: "deployment.yaml",
 					Path: "deployment.yaml",
 					Content: `apiVersion: apps/v1
@@ -103,6 +116,19 @@ metadata:
 		{
 			name: "resource without annotation with embeddedcluster api version but different group produces error",
 			specFiles: domain.SpecFiles{
+				{
+					Name: "helmchart.yaml",
+					Path: "helmchart.yaml",
+					Content: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: mychart
+spec:
+  chart:
+    name: mychart
+    chartVersion: 1.0.0
+`,
+				},
 				{
 					Name: "endpoints.yaml",
 					Path: "endpoints.yaml",
@@ -136,6 +162,19 @@ metadata:
 			name: "file in single subdirectory is still checked",
 			specFiles: domain.SpecFiles{
 				{
+					Name: "helmchart.yaml",
+					Path: "helmchart.yaml",
+					Content: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: mychart
+spec:
+  chart:
+    name: mychart
+    chartVersion: 1.0.0
+`,
+				},
+				{
 					Name: "deployment.yaml",
 					Path: "base/deployment.yaml",
 					Content: `apiVersion: apps/v1
@@ -156,6 +195,15 @@ metadata:
 					Name: "resources.yaml",
 					Path: "resources.yaml",
 					Content: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: mychart
+spec:
+  chart:
+    name: mychart
+    chartVersion: 1.0.0
+---
+apiVersion: kots.io/v1beta1
 kind: Config
 ---
 apiVersion: apps/v1
@@ -172,6 +220,19 @@ metadata:
 		{
 			name: "mixed annotated and unannotated resources",
 			specFiles: domain.SpecFiles{
+				{
+					Name: "helmchart.yaml",
+					Path: "helmchart.yaml",
+					Content: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: mychart
+spec:
+  chart:
+    name: mychart
+    chartVersion: 1.0.0
+`,
+				},
 				{
 					Name: "good.yaml",
 					Path: "good.yaml",
@@ -254,6 +315,11 @@ func Test_lintHelmInstallType_contextCancel(t *testing.T) {
 	cancel()
 
 	specFiles := domain.SpecFiles{
+		{
+			Name:    "helmchart.yaml",
+			Path:    "helmchart.yaml",
+			Content: "apiVersion: kots.io/v1beta1\nkind: HelmChart\n",
+		},
 		{
 			Name:    "deployment.yaml",
 			Path:    "deployment.yaml",

--- a/pkg/kots/helm_install_lint_test.go
+++ b/pkg/kots/helm_install_lint_test.go
@@ -1,0 +1,267 @@
+package kots
+
+import (
+	"context"
+	"testing"
+
+	"github.com/replicatedhq/kots-lint/pkg/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_lintHelmInstallType(t *testing.T) {
+	tests := []struct {
+		name              string
+		specFiles         domain.SpecFiles
+		expectErr         bool
+		expectExpressions int
+		expectRule        string
+		expectPaths       []string
+	}{
+		{
+			name:              "empty spec files returns no expressions",
+			specFiles:         domain.SpecFiles{},
+			expectExpressions: 0,
+		},
+		{
+			name: "replicated api version resource is skipped",
+			specFiles: domain.SpecFiles{
+				{
+					Name:    "installer.yaml",
+					Path:    "installer.yaml",
+					Content: "apiVersion: kots.io/v1beta1\nkind: Installer\n",
+				},
+			},
+			expectExpressions: 0,
+		},
+		{
+			name: "embeddedcluster replicated api version resource is skipped",
+			specFiles: domain.SpecFiles{
+				{
+					Name:    "install.yaml",
+					Path:    "install.yaml",
+					Content: "apiVersion: embeddedcluster.replicated.com/v1beta1\nkind: Installer\n",
+				},
+			},
+			expectExpressions: 0,
+		},
+		{
+			name: "cluster.kurl.sh api version resource is skipped",
+			specFiles: domain.SpecFiles{
+				{
+					Name:    "installer.yaml",
+					Path:    "installer.yaml",
+					Content: "apiVersion: cluster.kurl.sh/v1beta1\nkind: Installer\n",
+				},
+			},
+			expectExpressions: 0,
+		},
+		{
+			name: "troubleshoot.sh api version resource is skipped",
+			specFiles: domain.SpecFiles{
+				{
+					Name:    "preflight.yaml",
+					Path:    "preflight.yaml",
+					Content: "apiVersion: troubleshoot.sh/v1beta2\nkind: Preflight\n",
+				},
+			},
+			expectExpressions: 0,
+		},
+		{
+			name: "resource with kots.io/installer-only annotation is skipped",
+			specFiles: domain.SpecFiles{
+				{
+					Name: "deployment.yaml",
+					Path: "deployment.yaml",
+					Content: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kots.io/installer-only: "true"
+`,
+				},
+			},
+			expectExpressions: 0,
+		},
+		{
+			name: "resource without annotation returns lint error",
+			specFiles: domain.SpecFiles{
+				{
+					Name: "deployment.yaml",
+					Path: "deployment.yaml",
+					Content: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+`,
+				},
+			},
+			expectExpressions: 1,
+			expectRule:        "helm-install-type-missing-annotation",
+			expectPaths:       []string{"deployment.yaml"},
+		},
+		{
+			name: "resource without annotation with embeddedcluster api version but different group produces error",
+			specFiles: domain.SpecFiles{
+				{
+					Name: "endpoints.yaml",
+					Path: "endpoints.yaml",
+					Content: `apiVersion: apps/v1
+kind: Endpoints
+metadata:
+  name: test
+`,
+				},
+			},
+			expectExpressions: 1,
+			expectRule:        "helm-install-type-missing-annotation",
+			expectPaths:       []string{"endpoints.yaml"},
+		},
+		{
+			name: "files in subdirectories deeper than root are skipped",
+			specFiles: domain.SpecFiles{
+				{
+					Name: "deployment.yaml",
+					Path: "charts/subchart/deployment.yaml",
+					Content: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+`,
+				},
+			},
+			expectExpressions: 0,
+		},
+		{
+			name: "file in single subdirectory is still checked",
+			specFiles: domain.SpecFiles{
+				{
+					Name: "deployment.yaml",
+					Path: "base/deployment.yaml",
+					Content: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+`,
+				},
+			},
+			expectExpressions: 1,
+			expectRule:        "helm-install-type-missing-annotation",
+			expectPaths:       []string{"base/deployment.yaml"},
+		},
+		{
+			name: "multiple docs in a single file are separated and each checked",
+			specFiles: domain.SpecFiles{
+				{
+					Name: "resources.yaml",
+					Path: "resources.yaml",
+					Content: `apiVersion: kots.io/v1beta1
+kind: Config
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+`,
+				},
+			},
+			expectExpressions: 1,
+			expectRule:        "helm-install-type-missing-annotation",
+			expectPaths:       []string{"resources.yaml"},
+		},
+		{
+			name: "mixed annotated and unannotated resources",
+			specFiles: domain.SpecFiles{
+				{
+					Name: "good.yaml",
+					Path: "good.yaml",
+					Content: `apiVersion: apps/v1
+kind: Service
+metadata:
+  annotations:
+    kots.io/installer-only: "true"
+`,
+				},
+				{
+					Name: "bad.yaml",
+					Path: "bad.yaml",
+					Content: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+`,
+				},
+				{
+					Name: "replicated.yaml",
+					Path: "replicated.yaml",
+					Content: "apiVersion: kots.io/v1beta1\nkind: Config\n",
+				},
+			},
+			expectExpressions: 1,
+			expectRule:        "helm-install-type-missing-annotation",
+			expectPaths:       []string{"bad.yaml"},
+		},
+		{
+			name: "trailing separator produces empty doc that is skipped",
+			specFiles: domain.SpecFiles{
+				{
+					Name: "resources.yaml",
+					Path: "resources.yaml",
+					Content: `apiVersion: kots.io/v1beta1
+kind: Config
+---
+`,
+				},
+			},
+			expectExpressions: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			expressions, err := lintHelmInstallType(ctx, tt.specFiles)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Len(t, expressions, tt.expectExpressions)
+
+			if tt.expectRule != "" {
+				for _, e := range expressions {
+					assert.Equal(t, tt.expectRule, e.Rule)
+					assert.Equal(t, "error", e.Type)
+					assert.NotEmpty(t, e.Message)
+				}
+			}
+
+			if len(tt.expectPaths) > 0 {
+				paths := make([]string, len(expressions))
+				for i, e := range expressions {
+					paths[i] = e.Path
+				}
+				assert.ElementsMatch(t, tt.expectPaths, paths)
+			}
+		})
+	}
+}
+
+func Test_lintHelmInstallType_contextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	specFiles := domain.SpecFiles{
+		{
+			Name:    "deployment.yaml",
+			Path:    "deployment.yaml",
+			Content: "apiVersion: apps/v1\nkind: Deployment\n",
+		},
+	}
+
+	_, err := lintHelmInstallType(ctx, specFiles)
+	require.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
+}

--- a/pkg/kots/helm_install_lint_test.go
+++ b/pkg/kots/helm_install_lint_test.go
@@ -233,7 +233,7 @@ kind: Config
 			if tt.expectRule != "" {
 				for _, e := range expressions {
 					assert.Equal(t, tt.expectRule, e.Rule)
-					assert.Equal(t, "error", e.Type)
+					assert.Equal(t, "warn", e.Type)
 					assert.NotEmpty(t, e.Message)
 				}
 			}

--- a/pkg/kots/lint.go
+++ b/pkg/kots/lint.go
@@ -255,6 +255,11 @@ func LintSpecFiles(ctx context.Context, specFiles domain.SpecFiles) ([]domain.Li
 		return nil, false, errors.Wrap(err, "failed to lint helm charts with helm lint")
 	}
 
+	helmInstalTypeLintExpressions, err := lintHelmInstallType(ctx, renderedFiles)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "failed to lint helm install type")
+	}
+
 	allLintExpressions := []domain.LintExpression{}
 	allLintExpressions = append(allLintExpressions, yamlLintExpressions...)
 	allLintExpressions = append(allLintExpressions, opaNonRenderedLintExpressions...)
@@ -265,7 +270,7 @@ func LintSpecFiles(ctx context.Context, specFiles domain.SpecFiles) ([]domain.Li
 	allLintExpressions = append(allLintExpressions, embeddedClusterLintExpressions...)
 	allLintExpressions = append(allLintExpressions, chartTroubleshootLintExpressions...)
 	allLintExpressions = append(allLintExpressions, helmChartSchemaLintExpressions...)
-
+	allLintExpressions = append(allLintExpressions, helmInstalTypeLintExpressions...)
 	return allLintExpressions, true, nil
 }
 


### PR DESCRIPTION
## Summary

Adds a new lint check for Helm CLI install types that validates raw Kubernetes resources in the release root directory have the required "kots.io/installer-only" annotation.

## Rationale

The latest release promoted to the channel where the customer is assigned must contain one or more Helm charts. It can also include Replicated custom resources, such as the Embedded Cluster Config custom resource, the Replicated HelmChart, Config, and Application custom resources, or the Troubleshoot Preflight and SupportBundle custom resources.

Any other Kubernetes resources in the release (such as Kubernetes Deployments or Services) must include the kots.io/installer-only annotation.

## Testing

All tests pass:
- Unit tests for the new lint function
- Integration with existing lint pipeline


Example

```bash
COPYFILE_DISABLE=1 tar cvf - . | curl -H "content-type: application/tar" -XPOST --data-binary @- http://localhost:8082/v1/lint | jq
```

```json
{
  "lintExpressions": [
    {
      "rule": "helm-install-type-missing-annotation",
      "type": "warn",
      "message": "./dummy-deployment.yaml are raw Kubernetes resources without the kots.io/installer-only annotation. Add this annotation to the resource or remove it to enable Helm CLI install.",
      "path": "./dummy-deployment.yaml",
      "positions": null
    }
  ],
  "isLintingComplete": true
}

```