### PR TITLE
fix: process dependencies before coalescing values in helm-lint path

### DIFF
--- a/pkg/kots/helm_chart_lint.go
+++ b/pkg/kots/helm_chart_lint.go
@@ -74,6 +74,24 @@ func lintHelmChartsWithHelmLint(renderedFiles domain.SpecFiles, tarGzFiles domai
 			continue
 		}
 
+		// Process dependencies before coalescing so aliased subcharts are keyed under
+		// their alias (not their real Metadata.Name) and disabled subcharts are pruned.
+		// This mirrors helm's install/upgrade pipeline (action.install uses
+		// ProcessDependenciesWithMerge before rendering) and the other lint paths in
+		// this package. Without it, a dependency whose real name collides with a
+		// top-level parent values key merges its defaults under the wrong key and
+		// produces false-positive helm-schema-violations. Mutates ch in place, which is
+		// safe: the chart is loaded fresh for each archive in this loop.
+		if err := chartutil.ProcessDependenciesWithMerge(ch, builderValues); err != nil {
+			lintExpressions = append(lintExpressions, domain.LintExpression{
+				Rule:    "helm-schema-violation",
+				Type:    "warn",
+				Path:    tarGzFile.Path,
+				Message: fmt.Sprintf("Failed to process dependencies for chart %q: %v", ch.Name(), err),
+			})
+			continue
+		}
+
 		// Merge the chart's default values (values.yaml + dependency defaults) with the
 		// HelmChart spec.builder overrides so helm lint sees both.
 		merged, err := chartutil.CoalesceValues(ch, builderValues)

--- a/pkg/kots/helm_chart_lint_test.go
+++ b/pkg/kots/helm_chart_lint_test.go
@@ -111,6 +111,104 @@ spec:
           image: {{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag }}
 `
 
+// Regression: an umbrella chart whose dependency uses an `alias` where the
+// dependency's real name collides with a top-level values key the parent chart
+// itself uses. If dependencies are not processed before coalescing, the subchart
+// defaults are keyed under the subchart's real Metadata.Name ("envoyproxy")
+// instead of its alias ("gatewayenvoyproxy"), so they merge into the parent's
+// own `envoyproxy` workload map and corrupt it — producing false-positive
+// helm-schema-violations. Processing dependencies first scopes the subchart under
+// its alias, so the parent key stays clean and the chart lints cleanly (as
+// `helm lint`/`helm install` already do).
+const aliasCollisionChartYAML = `apiVersion: v2
+name: testchart
+version: 0.1.0
+dependencies:
+  - name: envoyproxy
+    version: 0.1.0
+    alias: gatewayenvoyproxy
+`
+
+// Parent uses `envoyproxy` as a map of workloads; each workload must carry a
+// resources block. Iterating a workload that lacks it dereferences a nil map and
+// fails to render.
+const aliasCollisionValuesYAML = `envoyproxy:
+  gateway1:
+    resources:
+      requests:
+        cpu: 100m
+`
+
+const aliasCollisionDeployment = `{{- range $name, $cfg := .Values.envoyproxy }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+data:
+  cpu: {{ $cfg.resources.requests.cpu }}
+{{- end }}
+`
+
+// The aliased subchart, keyed by its real name "envoyproxy", ships defaults that
+// do NOT carry a resources block — exactly the keys that corrupt the parent's
+// workload map when the alias is not applied.
+const aliasCollisionSubchartYAML = `apiVersion: v2
+name: envoyproxy
+version: 0.1.0
+`
+const aliasCollisionSubchartValues = `config:
+  foo: bar
+deployment:
+  replicas: 1
+`
+const aliasCollisionSubchartTemplate = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-config
+data:
+  foo: {{ .Values.config.foo }}
+`
+
+const aliasCollisionHelmChartCR = `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: testchart
+spec:
+  chart:
+    name: testchart
+    chartVersion: 0.1.0
+`
+
+func Test_lintHelmChartsWithHelmLint_aliasedDependencyCollision(t *testing.T) {
+	tarGzFiles := domain.SpecFiles{
+		{
+			Name: "testchart-0.1.0.tar.gz",
+			Path: "testchart-0.1.0.tar.gz",
+			Content: buildChartArchive(t, []tarChartFile{
+				chartFile("testchart/Chart.yaml", aliasCollisionChartYAML),
+				chartFile("testchart/values.yaml", aliasCollisionValuesYAML),
+				chartFile("testchart/templates/deployment.yaml", aliasCollisionDeployment),
+				chartFile("testchart/charts/envoyproxy/Chart.yaml", aliasCollisionSubchartYAML),
+				chartFile("testchart/charts/envoyproxy/values.yaml", aliasCollisionSubchartValues),
+				chartFile("testchart/charts/envoyproxy/templates/configmap.yaml", aliasCollisionSubchartTemplate),
+			}),
+		},
+	}
+
+	renderedFiles := domain.SpecFiles{
+		{
+			Name:    "helmchart.yaml",
+			Path:    "helmchart.yaml",
+			Content: aliasCollisionHelmChartCR,
+		},
+	}
+
+	expressions, err := lintHelmChartsWithHelmLint(renderedFiles, tarGzFiles)
+	require.NoError(t, err)
+	assert.Empty(t, expressions, "aliased dependency must be scoped under its alias so the parent's colliding key is not corrupted")
+}
+
 func Test_lintHelmChartsWithHelmLint(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
## Problem

`kots-lint` reports false-positive `helm-schema-violation`s for umbrella charts whose dependencies use an `alias`.

In `pkg/kots/helm_chart_lint.go`, merged values were built with `chartutil.CoalesceValues(ch, builderValues)` **without** first processing dependencies. This is the outlier — the other two lint paths in the package (`pkg/kots/helm.go`, `pkg/kots/troubleshoot_chart_lint.go`) both process dependencies first, as does helm's own install/upgrade/lint pipeline.

Because dependencies were never processed, subchart aliases were not applied. `CoalesceValues` keys each subchart's defaults under its real `Metadata.Name` rather than its alias. When a subchart's real name collides with a top-level key the parent chart already uses, the subchart defaults merge into the parent under the wrong key and corrupt it — surfacing as spurious schema/render errors even though `helm lint` and `helm install` pass cleanly.

Concrete case: dependency `name: envoyproxy`, `alias: gatewayenvoyproxy`; parent independently uses a top-level `envoyproxy:` workload map. Without alias processing the subchart defaults leak into the parent's `envoyproxy` key, and iterating those entries hits `nil pointer evaluating interface {}.requests`.

## Fix

Call `chartutil.ProcessDependenciesWithMerge(ch, builderValues)` before `CoalesceValues`, mirroring helm's install pipeline (`action.install`) and the other lint paths. Using the `WithMerge` + `builderValues` variant also honors `condition:` so disabled subcharts don't leak defaults — matching real install behavior.

## Test

Added `Test_lintHelmChartsWithHelmLint_aliasedDependencyCollision`, an umbrella chart with an aliased dependency whose real name collides with a parent top-level key. Verified it fails without the fix (reproduces the exact `nil pointer evaluating interface {}.requests` false positive) and passes with it.

Run the lint against a known chart now passing

```
 COPYFILE_DISABLE=1 tar cvf - . | curl -XPOST --data-binary @- http://localhost:8082/v1/lint

{"lintExpressions":[{"rule":"troubleshoot-spec","type":"warn","message":"Missing troubleshoot spec","path":"","positions":null},{"rule":"nonexistent-status-informer-object","type":"warn","message":"Status informer points to a nonexistent kubernetes object. If this is a Helm resource, this warning can be ignored.","path":"./kots-app.yaml","positions":[{"start":{"line":9}}]},{"rule":"invalid_type","type":"warn","message":"Invalid type. Expected: object, given: null","path":"./kots-chart.yaml","positions":[{"start":{"line":11}}]}],"isLintingComplete":true}
```

Refs: sc-138891