### PR TITLE
Update update-schemas workflow to Node 24 runtimes

### DIFF
--- a/.github/workflows/update-schemas.yaml
+++ b/.github/workflows/update-schemas.yaml
@@ -9,11 +9,11 @@ jobs:
   update-schemas:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - run: make schemas
 
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v8.1.1
         with:
           commit-message: "Update schemas from upstream projects"
           title: "Update schemas from upstream projects"


### PR DESCRIPTION
GitHub is deprecating Node 20 for GitHub Actions runtimes. This PR updates the update-schemas workflow to use action versions that run on Node 24.

Changes:
- `actions/checkout@v4` -> `actions/checkout@v7` (Node 24)
- `peter-evans/create-pull-request@v6` -> `peter-evans/create-pull-request@v8.1.1` (Node 24)

This resolves the "Node.js 20 is deprecated" warning seen in recent update-schemas workflow runs.